### PR TITLE
Prevent zoom on touch (Safari)

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content, user-scalable=no">
     <title>{{ $title ?? 'Many Notes' }}</title>
     <link rel="icon" type="image/png" href="/assets/icon-16x16.png" sizes="16x16">
     <link rel="icon" type="image/png" href="/assets/icon-32x32.png" sizes="32x32">


### PR DESCRIPTION
Disables automatic zooming on Apple phones.
https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html