### PR TITLE
Improve tree view by adding indents and vertical lines and aligning texts

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -74,6 +74,10 @@
         cursor: pointer;
     }
 
+    .tree-view-directory {
+        border-left: 2px solid #e9ecef;
+    }
+
     .prose {
         h1 {
             font-size: 1.75em !important;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -74,11 +74,6 @@
         cursor: pointer;
     }
 
-    .tree-view-directory {
-        @apply pl-2 ml-2;
-        border-left: 2px solid #e9ecef;
-    }
-
     .prose {
         h1 {
             font-size: 1.75em !important;

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -75,6 +75,7 @@
     }
 
     .tree-view-directory {
+        @apply pl-2 ml-2;
         border-left: 2px solid #e9ecef;
     }
 

--- a/resources/views/components/treeView/itemFile.blade.php
+++ b/resources/views/components/treeView/itemFile.blade.php
@@ -4,7 +4,7 @@
     <x-menu>
         <a
             href=""
-            class="flex items-center w-full gap-2"
+            class="flex items-center w-full gap-2 pl-4"
             title="{{ $node->name }}"
             x-ref="button"
             @click.prevent="openFile({{ $node->id }})"

--- a/resources/views/components/treeView/itemFolder.blade.php
+++ b/resources/views/components/treeView/itemFolder.blade.php
@@ -9,7 +9,7 @@
     <x-menu class="flex flex-grow">
         <a
             href=""
-            class="flex items-center w-full"
+            class="flex items-center w-full pl-4"
             title="{{ $node->name }}"
             x-ref="button"
             @click.prevent="accordionOpen = !accordionOpen"
@@ -17,8 +17,8 @@
             @keydown.escape="menuOpen = false"
             @auxclick.outside="menuOpen = false"
         >
-            <x-icons.chevronRight x-show="!accordionOpen" class="w-4 h-4" />
-            <x-icons.chevronDown x-show="accordionOpen" class="w-4 h-4" x-cloak />
+            <x-icons.chevronRight x-show="!accordionOpen" class="w-4 h-4 -ml-4" />
+            <x-icons.chevronDown x-show="accordionOpen" class="w-4 h-4 -ml-4" x-cloak />
 
             <span class="ml-1 overflow-hidden whitespace-nowrap text-ellipsis">
                 {{ $node->name }}

--- a/resources/views/components/treeView/items.blade.php
+++ b/resources/views/components/treeView/items.blade.php
@@ -1,8 +1,10 @@
 @props(['root'])
 
 <ul
-    @unless ($root)
-        class="relative w-full pl-2 ml-2 tree-view-directory"
+    @if ($root)
+        class="relative w-full"
+    @else
+        class="relative w-full tree-view-directory"
         x-show="accordionOpen"
         x-collapse
         x-cloak

--- a/resources/views/components/treeView/items.blade.php
+++ b/resources/views/components/treeView/items.blade.php
@@ -1,8 +1,8 @@
 @props(['root'])
 
 <ul
-    class="relative w-full pl-4 first:pl-0"
     @unless ($root)
+        class="relative w-full pl-2 ml-2 tree-view-directory"
         x-show="accordionOpen"
         x-collapse
         x-cloak

--- a/resources/views/components/treeView/items.blade.php
+++ b/resources/views/components/treeView/items.blade.php
@@ -4,7 +4,7 @@
     @if ($root)
         class="relative w-full"
     @else
-        class="relative w-full tree-view-directory"
+        class="relative w-full pl-2 ml-2 border-l-2 border-light-base-400 dark:border-base-500"
         x-show="accordionOpen"
         x-collapse
         x-cloak

--- a/resources/views/livewire/vault/treeView.blade.php
+++ b/resources/views/livewire/vault/treeView.blade.php
@@ -22,7 +22,7 @@
                 @mouseenter="hovered = true"
                 @mouseleave="hovered = false"
             >
-                <h3>{{ $vault->name }}</h3>
+                <h3 class="pl-4 font-semibold">{{ $vault->name }}</h3>
 
                 <div
                     class="flex items-center"


### PR DESCRIPTION
Improve tree view by
* indenting directory contents one level below the directory name,
* aligning the text of directories and files within the same directory, and
* adding vertical lines that span the contents of directories

Closes #80