### PR TITLE
feat: read-only shareable note links

### DIFF
--- a/app/Actions/CreateVaultNodeShare.php
+++ b/app/Actions/CreateVaultNodeShare.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\VaultNode;
+use App\Models\VaultNodeShare;
+use Illuminate\Support\Str;
+
+final readonly class CreateVaultNodeShare
+{
+    public function handle(VaultNode $node): VaultNodeShare
+    {
+        /** @var VaultNodeShare $share */
+        $share = VaultNodeShare::query()->firstOrCreate(
+            ['vault_node_id' => $node->id],
+            ['token' => Str::random(48)],
+        );
+
+        return $share;
+    }
+}

--- a/app/Actions/DeleteVaultNodeShare.php
+++ b/app/Actions/DeleteVaultNodeShare.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\VaultNode;
+
+final readonly class DeleteVaultNodeShare
+{
+    public function handle(VaultNode $node): void
+    {
+        $node->share()->delete();
+    }
+}

--- a/app/Actions/GetReferencedImageNodesFromContent.php
+++ b/app/Actions/GetReferencedImageNodesFromContent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Enums\VaultNodeType;
+use App\Models\VaultNode;
+
+final readonly class GetReferencedImageNodesFromContent
+{
+    public function __construct(
+        private ResolveTwoPaths $resolveTwoPaths,
+        private GetVaultNodeFromPath $getVaultNodeFromPath,
+    ) {
+        //
+    }
+
+    /** @return list<VaultNode> */
+    public function handle(VaultNode $node): array
+    {
+        /** @var string $content */
+        $content = $node->content ?? '';
+
+        if (preg_match_all('/!\[[^\]]*]\(([^)\s]+)(?:\s+"[^"]*")?\)/', $content, $matches) === false) {
+            return [];
+        }
+
+        $currentPath = $node->fullPath();
+        $imageNodes = [];
+
+        foreach (array_unique($matches[1]) as $path) {
+            if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://')) {
+                continue;
+            }
+
+            $resolvedPath = $this->resolveTwoPaths->handle($currentPath, $path);
+            $imageNode = $this->getVaultNodeFromPath->handle($node->vault_id, $resolvedPath);
+
+            if ($imageNode !== null && $imageNode->type() === VaultNodeType::IMAGE) {
+                $imageNodes[$imageNode->id] = $imageNode;
+            }
+        }
+
+        return array_values($imageNodes);
+    }
+}

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\VaultNodeShare;
+use App\ViewModels\ShareViewModel;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final readonly class ShareController
+{
+    public function show(VaultNodeShare $share): Response
+    {
+        return Inertia::render('share/Show', [
+            'share' => ShareViewModel::fromModel($share),
+        ]);
+    }
+}

--- a/app/Http/Controllers/ShareFileController.php
+++ b/app/Http/Controllers/ShareFileController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Actions\GetPathFromVaultNode;
+use App\Actions\GetReferencedImageNodesFromContent;
+use App\Actions\GetVaultNodeFromPath;
+use App\Models\VaultNode;
+use App\Models\VaultNodeShare;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+final readonly class ShareFileController
+{
+    public function show(
+        Request $request,
+        VaultNodeShare $share,
+        GetVaultNodeFromPath $getVaultNodeFromPath,
+        GetReferencedImageNodesFromContent $getReferencedImageNodesFromContent,
+        GetPathFromVaultNode $getPathFromVaultNode,
+    ): BinaryFileResponse {
+        abort_unless($request->has('path'), 404);
+
+        /** @var string $path */
+        $path = $request->path;
+
+        $node = $getVaultNodeFromPath->handle($share->node->vault_id, $path);
+
+        abort_unless($node !== null, 404);
+
+        // Only files actually referenced as images in the shared note's current
+        // content are servable, regardless of what else lives in the vault.
+        $allowedNodeIds = array_map(
+            fn(VaultNode $imageNode): int => $imageNode->id,
+            $getReferencedImageNodesFromContent->handle($share->node),
+        );
+
+        abort_unless(in_array($node->id, $allowedNodeIds, true), 404);
+
+        $relativePath = $getPathFromVaultNode->handle($node);
+        $absolutePath = Storage::disk('local')->path($relativePath);
+
+        return response()->file($absolutePath);
+    }
+}

--- a/app/Http/Controllers/VaultController.php
+++ b/app/Http/Controllers/VaultController.php
@@ -78,6 +78,8 @@ final readonly class VaultController
                 abort_unless($file !== null, 404);
             }
 
+            $file->load('share');
+
             $data = [
                 ...$data,
                 'openedFile' => [

--- a/app/Http/Controllers/VaultNodeShareController.php
+++ b/app/Http/Controllers/VaultNodeShareController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Actions\CreateVaultNodeShare;
+use App\Actions\DeleteVaultNodeShare;
+use App\Enums\VaultNodeType;
+use App\Models\User;
+use App\Models\Vault;
+use App\Models\VaultNode;
+use Illuminate\Container\Attributes\CurrentUser;
+use Illuminate\Http\JsonResponse;
+
+final readonly class VaultNodeShareController
+{
+    public function store(
+        Vault $vault,
+        VaultNode $node,
+        #[CurrentUser] User $user,
+        CreateVaultNodeShare $createVaultNodeShare,
+    ): JsonResponse {
+        abort_unless($user->can('share', $node), 403);
+        abort_unless($node->is_file && $node->type() === VaultNodeType::NOTE, 422);
+
+        $share = $createVaultNodeShare->handle($node);
+
+        return response()->json([
+            'data' => [
+                'token' => $share->token,
+                'url' => route('share.show', ['share' => $share->token]),
+            ],
+        ]);
+    }
+
+    public function destroy(
+        Vault $vault,
+        VaultNode $node,
+        #[CurrentUser] User $user,
+        DeleteVaultNodeShare $deleteVaultNodeShare,
+    ): JsonResponse {
+        abort_unless($user->can('share', $node), 403);
+
+        $deleteVaultNodeShare->handle($node);
+
+        return response()->json([
+            'data' => null,
+        ]);
+    }
+}

--- a/app/Models/VaultNode.php
+++ b/app/Models/VaultNode.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Laravel\Scout\Searchable;
 use Override;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
@@ -38,6 +39,7 @@ use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
  * @property-read Collection<int, VaultNode> $links
  * @property-read Collection<int, VaultNode> $backlinks
  * @property-read Collection<int, Tag> $tags
+ * @property-read VaultNodeShare|null $share
  */
 final class VaultNode extends Model
 {
@@ -78,6 +80,12 @@ final class VaultNode extends Model
     {
         return $this->belongsToMany(Tag::class, null, 'vault_node_id', 'tag_id')
             ->withPivot('position');
+    }
+
+    /** @return HasOne<VaultNodeShare, $this> */
+    public function share(): HasOne
+    {
+        return $this->hasOne(VaultNodeShare::class);
     }
 
     public function isTemplate(): bool

--- a/app/Models/VaultNodeShare.php
+++ b/app/Models/VaultNodeShare.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonImmutable;
+use Database\Factories\VaultNodeShareFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property-read int $id
+ * @property-read int $vault_node_id
+ * @property-read string $token
+ * @property-read CarbonImmutable $created_at
+ * @property-read CarbonImmutable $updated_at
+ * @property-read VaultNode $node
+ */
+final class VaultNodeShare extends Model
+{
+    /** @use HasFactory<VaultNodeShareFactory> */
+    use HasFactory;
+
+    /** @return BelongsTo<VaultNode, $this> */
+    public function node(): BelongsTo
+    {
+        return $this->belongsTo(VaultNode::class, 'vault_node_id');
+    }
+}

--- a/app/Policies/VaultNodePolicy.php
+++ b/app/Policies/VaultNodePolicy.php
@@ -24,4 +24,19 @@ final readonly class VaultNodePolicy
                 ->wherePivot('accepted', true)
                 ->exists();
     }
+
+    /**
+     * Determine whether the user can create or revoke a public share link for the model.
+     */
+    public function share(User $user, VaultNode $node): bool
+    {
+        /** @var Vault $vault */
+        $vault = $node->vault;
+
+        return $user->id === $vault->created_by ||
+            $vault->collaborators()
+                ->wherePivot('user_id', $user->id)
+                ->wherePivot('accepted', true)
+                ->exists();
+    }
 }

--- a/app/ViewModels/ShareViewModel.php
+++ b/app/ViewModels/ShareViewModel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ViewModels;
+
+use App\Models\VaultNodeShare;
+use Carbon\CarbonImmutable;
+
+final readonly class ShareViewModel
+{
+    public function __construct(
+        public string $token,
+        public string $name,
+        public ?string $content,
+        public ?CarbonImmutable $updated_at,
+    ) {
+        //
+    }
+
+    public static function fromModel(VaultNodeShare $share): self
+    {
+        return new self(
+            $share->token,
+            $share->node->name,
+            $share->node->content,
+            $share->node->updated_at,
+        );
+    }
+}

--- a/app/ViewModels/VaultNodeViewModel.php
+++ b/app/ViewModels/VaultNodeViewModel.php
@@ -21,6 +21,7 @@ final readonly class VaultNodeViewModel
         public string $full_path,
         public string $url,
         public ?string $content,
+        public ?string $share_url,
         public ?CarbonImmutable $updated_at,
     ) {
         //
@@ -31,6 +32,9 @@ final readonly class VaultNodeViewModel
         $extension = $node->extension ? ".{$node->extension}" : '';
         $fullPath = "/{$node->fullPath()}{$extension}";
         $url = $node->is_file ? app(GetUrlFromVaultNode::class)->handle($node) : '';
+        $shareUrl = $node->relationLoaded('share') && $node->share !== null
+            ? route('share.show', ['share' => $node->share->token])
+            : null;
 
         return new self(
             $node->id,
@@ -43,6 +47,7 @@ final readonly class VaultNodeViewModel
             $fullPath,
             $url,
             $node->content,
+            $shareUrl,
             $node->updated_at,
         );
     }

--- a/database/factories/VaultNodeShareFactory.php
+++ b/database/factories/VaultNodeShareFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\VaultNode;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\VaultNodeShare>
+ */
+final class VaultNodeShareFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'vault_node_id' => VaultNode::factory(),
+            'token' => Str::random(48),
+        ];
+    }
+}

--- a/database/migrations/2025_08_26_120000_create_vault_node_shares_table.php
+++ b/database/migrations/2025_08_26_120000_create_vault_node_shares_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vault_node_shares', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('vault_node_id')->unique()->constrained('vault_nodes')->cascadeOnDelete();
+            $table->string('token', 48)->unique();
+            $table->timestamps();
+        });
+    }
+};

--- a/resources/js/components/editor/MarkdownToolbar.vue
+++ b/resources/js/components/editor/MarkdownToolbar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import VaultEditorApplyTemplateController from '@/actions/App/Http/Controllers/VaultEditorApplyTemplateController';
 import Menu from '@/components/menu/Menu.vue';
+import NoteShareModal from '@/components/modal/NoteShareModal.vue';
 import VaultEditorSearchFileModal from '@/components/modal/VaultEditorSearchModal.vue';
 import VaultEditorTemplateListModal from '@/components/modal/VaultEditorTemplateListModal.vue';
 import { useAxiosForm } from '@/composables/useAxiosForm';
@@ -35,6 +36,7 @@ import Pilcrow from '@/icons/Pilcrow.vue';
 import Print from '@/icons/Print.vue';
 import Quote from '@/icons/Quote.vue';
 import Redo from '@/icons/Redo.vue';
+import Share from '@/icons/Share.vue';
 import Strike from '@/icons/Strike.vue';
 import TableAdd from '@/icons/TableAdd.vue';
 import TableAddColumn from '@/icons/TableAddColumn.vue';
@@ -54,6 +56,11 @@ import MarkdownToolbarSubButton from './MarkdownToolbarSubButton.vue';
 const props = defineProps<{
     vaultId: number;
     nodeId: number;
+    shareUrl: string | null;
+}>();
+
+const emit = defineEmits<{
+    'share-updated': [url: string | null];
 }>();
 
 const { openModal } = useModalManager();
@@ -228,6 +235,16 @@ function setTableColumnAlignment(alignment: 'left' | 'center' | 'right'): void {
 
 function print(): void {
     globalThis.print();
+}
+
+function openShareModal(): void {
+    openModal(NoteShareModal, {
+        title: 'Share note',
+        vaultId: props.vaultId,
+        nodeId: props.nodeId,
+        shareUrl: props.shareUrl,
+        onUpdate: (url: string | null) => emit('share-updated', url),
+    });
 }
 </script>
 
@@ -502,6 +519,17 @@ function print(): void {
                 @click="toggleEditMode"
             />
             <MarkdownToolbarButton title="Print" :icon="Print" @click="print" />
+            <MarkdownToolbarButton
+                title="Share"
+                :icon="Share"
+                :toggle="true"
+                :class="
+                    shareUrl
+                        ? 'bg-primary-400 dark:bg-primary-500 text-light-base-50! dark:text-light-base-50!'
+                        : ''
+                "
+                @click="openShareModal"
+            />
         </div>
     </div>
 </template>

--- a/resources/js/components/menu/GuestMenu.vue
+++ b/resources/js/components/menu/GuestMenu.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import Menu from '@/components/menu/Menu.vue';
+import MenuDivider from '@/components/menu/MenuDivider.vue';
+import MenuItem from '@/components/menu/MenuItem.vue';
+import AboutModal from '@/components/modal/AboutModal.vue';
+import { useModalManager } from '@/composables/useModalManager';
+import { useTheme } from '@/composables/useTheme';
+import Cog6Tooth from '@/icons/Cog6Tooth.vue';
+import InformationCircle from '@/icons/InformationCircle.vue';
+import Moon from '@/icons/Moon.vue';
+
+const { isDark, toggleTheme } = useTheme();
+const { openModal } = useModalManager();
+</script>
+
+<template>
+    <Menu type="dropdown">
+        <template #trigger>
+            <Cog6Tooth class="h-5 w-5" />
+        </template>
+
+        <template #default="{ closeMenu }">
+            <div class="min-w-[12rem]">
+                <MenuItem @click="toggleTheme">
+                    <span class="flex w-full items-center justify-between">
+                        <span class="flex items-center gap-2">
+                            <Moon class="h-4 w-4" />
+                            Dark mode
+                        </span>
+                        <span
+                            class="relative inline-flex h-5 w-10 items-center rounded-full transition-colors"
+                            :class="
+                                isDark
+                                    ? 'bg-primary-300 dark:bg-primary-600'
+                                    : 'bg-gray-200 dark:bg-gray-700'
+                            "
+                        >
+                            <span
+                                class="absolute h-4.5 w-4.5 transform rounded-full border border-gray-300 bg-white transition-all"
+                                :class="
+                                    isDark
+                                        ? 'translate-x-5 border-white rtl:-translate-x-5'
+                                        : 'translate-x-0 rtl:translate-x-0 dark:border-gray-600'
+                                "
+                            ></span>
+                        </span>
+                    </span>
+                </MenuItem>
+
+                <MenuDivider />
+
+                <MenuItem
+                    label="About"
+                    :icon="InformationCircle"
+                    @click="
+                        closeMenu();
+                        openModal(AboutModal, { title: 'About' });
+                    "
+                />
+            </div>
+        </template>
+    </Menu>
+</template>

--- a/resources/js/components/modal/NoteShareModal.vue
+++ b/resources/js/components/modal/NoteShareModal.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { destroy, store } from '@/actions/App/Http/Controllers/VaultNodeShareController';
+import ModelInput from '@/components/form/ModelInput.vue';
+import Submit from '@/components/form/Submit.vue';
+import SecondaryButton from '@/components/ui/SecondaryButton.vue';
+import { useAxiosForm } from '@/composables/useAxiosForm';
+import { useModalManager } from '@/composables/useModalManager';
+import { useToast } from '@/composables/useToast';
+import Trash from '@/icons/Trash.vue';
+import { ref } from 'vue';
+
+const { closeModal } = useModalManager();
+const { createToast } = useToast();
+
+const props = defineProps<{
+    vaultId: number;
+    nodeId: number;
+    shareUrl: string | null;
+    onUpdate: (url: string | null) => void;
+}>();
+
+const shareUrl = ref(props.shareUrl);
+const isConfirmingRevoke = ref(false);
+const isCopied = ref(false);
+
+let copiedTimeout: ReturnType<typeof setTimeout> | null = null;
+
+const form = useAxiosForm({});
+
+const createLink = () => {
+    form.send<{ data: { url: string } }>({
+        url: store.url({ vault: props.vaultId, node: props.nodeId }),
+        method: 'post',
+        onError: error => {
+            const message = error.response?.statusText ?? 'Something went wrong';
+            createToast(message, 'error');
+        },
+        onSuccess: payload => {
+            shareUrl.value = payload.data.url;
+            props.onUpdate(shareUrl.value);
+        },
+    });
+};
+
+const copyLink = async () => {
+    if (!shareUrl.value) {
+        return;
+    }
+
+    await navigator.clipboard.writeText(shareUrl.value);
+
+    isCopied.value = true;
+
+    if (copiedTimeout) {
+        clearTimeout(copiedTimeout);
+    }
+
+    copiedTimeout = setTimeout(() => {
+        isCopied.value = false;
+    }, 2000);
+};
+
+const confirmRevoke = () => {
+    form.send({
+        url: destroy.url({ vault: props.vaultId, node: props.nodeId }),
+        method: 'delete',
+        onError: error => {
+            isConfirmingRevoke.value = false;
+            const message = error.response?.statusText ?? 'Something went wrong';
+            createToast(message, 'error');
+        },
+        onSuccess: () => {
+            shareUrl.value = null;
+            props.onUpdate(null);
+            closeModal();
+        },
+    });
+};
+</script>
+
+<template>
+    <div class="flex flex-col gap-6">
+        <template v-if="isConfirmingRevoke">
+            <p class="text-sm opacity-75">
+                Are you sure you want to revoke this share link? Anyone using it will no longer be
+                able to view this note.
+            </p>
+            <div class="flex justify-end gap-2 py-1">
+                <SecondaryButton :disabled="form.processing" @click="isConfirmingRevoke = false">
+                    Cancel
+                </SecondaryButton>
+                <Submit label="Revoke link" :processing="form.processing" @click="confirmRevoke" />
+            </div>
+        </template>
+        <template v-else-if="shareUrl">
+            <p class="text-sm opacity-75">
+                Anyone with this link can view a read-only version of this note. It stays up to date
+                with your edits until you revoke it.
+            </p>
+            <div class="flex items-end gap-2">
+                <ModelInput
+                    class="grow"
+                    name="share_url"
+                    type="text"
+                    :model-value="shareUrl"
+                    readonly
+                    @focus="($event.target as HTMLInputElement).select()"
+                />
+                <SecondaryButton @click="copyLink">{{
+                    isCopied ? 'Copied!' : 'Copy'
+                }}</SecondaryButton>
+            </div>
+            <div class="flex justify-end">
+                <button
+                    type="button"
+                    class="text-error-500 flex items-center gap-1 text-sm font-semibold"
+                    @click="isConfirmingRevoke = true"
+                >
+                    <Trash class="h-4 w-4" />
+                    Revoke link
+                </button>
+            </div>
+        </template>
+        <template v-else>
+            <p class="text-sm opacity-75">
+                Create a public, read-only link to this note. Anyone with the link can view it
+                without an account.
+            </p>
+            <form
+                class="flex flex-col gap-6 inert:pointer-events-none"
+                :inert="form.processing"
+                @submit.prevent="createLink"
+            >
+                <div class="flex justify-end gap-2 py-1">
+                    <Submit label="Create link" :processing="form.processing" />
+                </div>
+            </form>
+        </template>
+    </div>
+</template>

--- a/resources/js/composables/useEditor.ts
+++ b/resources/js/composables/useEditor.ts
@@ -26,6 +26,7 @@ interface SetupEditorOptions {
     isEditMode: Readonly<Ref<boolean>>;
     onUpdate: (markdown: string) => void;
     openFilePath: (path: string) => void;
+    imageBaseUrl?: string;
 }
 
 export function useEditor(options: SetupEditorOptions) {
@@ -101,6 +102,7 @@ export function useEditor(options: SetupEditorOptions) {
                 }),
                 CustomImage.configure({
                     vaultId: options.vaultId,
+                    baseUrl: options.imageBaseUrl ?? null,
                 }),
                 CustomLink.configure({
                     autolink: false,

--- a/resources/js/icons/Share.vue
+++ b/resources/js/icons/Share.vue
@@ -1,0 +1,17 @@
+<template>
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <g
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+        >
+            <circle cx="18" cy="5" r="2.5" />
+            <circle cx="6" cy="12" r="2.5" />
+            <circle cx="18" cy="19" r="2.5" />
+            <path d="M8.2 10.7L15.8 6.6" />
+            <path d="M8.2 13.3L15.8 17.4" />
+        </g>
+    </svg>
+</template>

--- a/resources/js/layouts/PublicLayout.vue
+++ b/resources/js/layouts/PublicLayout.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import GuestMenu from '@/components/menu/GuestMenu.vue';
+import ModalManager from '@/components/modal/ModalManager.vue';
+import AppLayout from './AppLayout.vue';
+</script>
+
+<template>
+    <AppLayout>
+        <main
+            class="bg-light-base-50 dark:bg-base-900 text-light-base-950 dark:text-base-50 relative flex-1 overflow-y-auto"
+        >
+            <div class="absolute top-4 right-4 print:hidden">
+                <GuestMenu />
+            </div>
+
+            <div class="mx-auto max-w-[48rem] px-4 py-8">
+                <slot />
+            </div>
+        </main>
+
+        <ModalManager />
+    </AppLayout>
+</template>

--- a/resources/js/pages/share/Show.vue
+++ b/resources/js/pages/share/Show.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import MarkdownToolbarButton from '@/components/editor/MarkdownToolbarButton.vue';
+import { useEditor } from '@/composables/useEditor';
+import CheckCircle from '@/icons/CheckCircle.vue';
+import DocumentDuplicate from '@/icons/DocumentDuplicate.vue';
+import Print from '@/icons/Print.vue';
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { formatExtendedDate } from '@/utils/time';
+import { Head } from '@inertiajs/vue3';
+import { ref } from 'vue';
+
+interface ShareShowPageProps {
+    share: {
+        token: string;
+        name: string;
+        content: string | null;
+        updated_at: string | null;
+    };
+}
+
+const props = defineProps<ShareShowPageProps>();
+
+const noteEditorRef = ref<HTMLElement | null>(null);
+const noteMarkdownRef = ref<HTMLElement | null>(null);
+const isCopied = ref(false);
+
+let copiedTimeout: ReturnType<typeof setTimeout> | null = null;
+
+useEditor({
+    vaultId: '',
+    element: noteEditorRef,
+    markdownElement: noteMarkdownRef,
+    content: props.share.content ?? '',
+    isEditMode: ref(false),
+    imageBaseUrl: `/share/${props.share.token}/files`,
+    onUpdate: () => {
+        //
+    },
+    openFilePath: () => {
+        //
+    },
+});
+
+function print(): void {
+    globalThis.print();
+}
+
+async function copyMarkdown(): Promise<void> {
+    await navigator.clipboard.writeText(props.share.content ?? '');
+
+    isCopied.value = true;
+
+    if (copiedTimeout) {
+        clearTimeout(copiedTimeout);
+    }
+
+    copiedTimeout = setTimeout(() => {
+        isCopied.value = false;
+    }, 1000);
+}
+</script>
+
+<template>
+    <PublicLayout>
+        <Head :title="share.name" />
+
+        <div class="flex items-start justify-between gap-4 pb-6">
+            <div class="flex flex-col gap-1">
+                <h1 class="text-2xl font-semibold break-words">{{ share.name }}</h1>
+                <p v-if="share.updated_at" class="text-sm opacity-60">
+                    Last updated {{ formatExtendedDate(share.updated_at) }}
+                </p>
+            </div>
+
+            <div class="flex shrink-0 gap-1 print:hidden">
+                <MarkdownToolbarButton title="Print" :icon="Print" @click="print" />
+                <MarkdownToolbarButton
+                    :title="isCopied ? 'Copied!' : 'Copy markdown'"
+                    :icon="isCopied ? CheckCircle : DocumentDuplicate"
+                    @click="copyMarkdown"
+                />
+            </div>
+        </div>
+
+        <div ref="noteEditorRef" class="w-full" spellcheck="false"></div>
+        <div ref="noteMarkdownRef" class="hidden"></div>
+    </PublicLayout>
+</template>

--- a/resources/js/pages/vault/Show.vue
+++ b/resources/js/pages/vault/Show.vue
@@ -308,7 +308,12 @@ useEcho<{ data: { user_id: number } }>(
                     @name-updated="openedFile.file.name = $event"
                 >
                     <template v-if="openedFile.file.type === 'note'" #toolbar>
-                        <MarkdownToolbar :vault-id="props.vault.id" :node-id="openedFile.file.id" />
+                        <MarkdownToolbar
+                            :vault-id="props.vault.id"
+                            :node-id="openedFile.file.id"
+                            :share-url="openedFile.file.share_url"
+                            @share-updated="openedFile.file.share_url = $event"
+                        />
                     </template>
                     <component
                         :is="fileComponents[openedFile.file.type]"

--- a/resources/js/services/tiptap/extension-custom-image.ts
+++ b/resources/js/services/tiptap/extension-custom-image.ts
@@ -3,6 +3,7 @@ import Image, { ImageOptions } from '@tiptap/extension-image';
 
 export interface CustomImageOptions extends ImageOptions {
     vaultId: string | null;
+    baseUrl: string | null;
 }
 
 export const CustomImage = Image.extend<CustomImageOptions>({
@@ -10,14 +11,18 @@ export const CustomImage = Image.extend<CustomImageOptions>({
         return {
             ...this.parent!(),
             vaultId: null,
+            baseUrl: null,
         };
     },
 
     renderHTML({ HTMLAttributes }) {
         const { src, ...rest } = HTMLAttributes;
+        const baseUrl =
+            this.options.baseUrl ??
+            (this.options.vaultId ? `/files/${this.options.vaultId}` : null);
         const resolvedSrc =
-            src && !src.startsWith('http://') && !src.startsWith('https://') && this.options.vaultId
-                ? `/files/${this.options.vaultId}?path=${src}`
+            src && !src.startsWith('http://') && !src.startsWith('https://') && baseUrl
+                ? `${baseUrl}?path=${src}`
                 : src;
 
         return ['img', mergeAttributes(this.options.HTMLAttributes, { ...rest, src: resolvedSrc })];

--- a/resources/js/types/vault.ts
+++ b/resources/js/types/vault.ts
@@ -38,6 +38,7 @@ export interface VaultNode {
     full_path: string;
     url: string;
     content: string | null;
+    share_url: string | null;
     updated_at: string;
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\PasswordController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SettingController;
+use App\Http\Controllers\ShareController;
+use App\Http\Controllers\ShareFileController;
 use App\Http\Controllers\VaultCollaborationAcceptController;
 use App\Http\Controllers\VaultCollaborationController;
 use App\Http\Controllers\VaultCollaborationDeclineController;
@@ -25,6 +27,7 @@ use App\Http\Controllers\VaultNodeChildrenController;
 use App\Http\Controllers\VaultNodeController;
 use App\Http\Controllers\VaultNodeImportController;
 use App\Http\Controllers\VaultNodeMoveController;
+use App\Http\Controllers\VaultNodeShareController;
 use App\Http\Controllers\VaultSearchController;
 use App\Http\Middleware\EnsureEmailIsConfigured;
 use App\Http\Middleware\EnsureRegistrationIsEnabled;
@@ -56,6 +59,8 @@ Route::middleware('auth')->group(function (): void {
             Route::delete('', [VaultNodeController::class, 'destroy'])->name('destroy');
             Route::get('children', VaultNodeChildrenController::class)->name('children');
             Route::patch('move', VaultNodeMoveController::class)->name('move');
+            Route::post('share', [VaultNodeShareController::class, 'store'])->name('share.store');
+            Route::delete('share', [VaultNodeShareController::class, 'destroy'])->name('share.destroy');
         })->scopeBindings();
 
         Route::post('import', VaultNodeImportController::class)->name('import');
@@ -111,4 +116,10 @@ Route::middleware(['guest', 'throttle'])->group(function (): void {
         Route::get('{provider}', [OAuthController::class, 'create'])->name('oauth');
         Route::get('{provider}/callback', [OAuthController::class, 'store'])->name('oauth.store');
     });
+});
+
+// Public, unauthenticated read-only note links
+Route::middleware('throttle')->prefix('share')->name('share.')->group(function (): void {
+    Route::get('{share:token}', [ShareController::class, 'show'])->name('show');
+    Route::get('{share:token}/files', [ShareFileController::class, 'show'])->name('files');
 });

--- a/tests/Feature/Web/Share/ShareFileControllerTest.php
+++ b/tests/Feature/Web/Share/ShareFileControllerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateVault;
+use App\Actions\CreateVaultNode;
+use App\Actions\CreateVaultNodeShare;
+use App\Actions\GetPathFromVaultNode;
+use App\Actions\GetUrlFromVaultNode;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+it('serves an image referenced in the shared note content', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $image = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => 'picture',
+        'extension' => 'jpg',
+    ]);
+    $imagePath = new GetPathFromVaultNode()->handle($image);
+    Storage::disk('local')->put($imagePath, 'binary-data');
+    $imageUrl = new GetUrlFromVaultNode()->handle($image);
+    $imagePathParam = mb_substr($imageUrl, mb_strpos($imageUrl, 'path=') + mb_strlen('path='));
+
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => "![alt]({$imagePathParam})",
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+
+    $this->get(route('share.files', ['share' => $share->token]) . '?path=' . $imagePathParam)
+        ->assertStatus(200);
+});
+
+it('does not serve a file that is not referenced in the shared note', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $unrelatedImage = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => 'unrelated',
+        'extension' => 'jpg',
+    ]);
+    $imagePath = new GetPathFromVaultNode()->handle($unrelatedImage);
+    Storage::disk('local')->put($imagePath, 'binary-data');
+    $imageUrl = new GetUrlFromVaultNode()->handle($unrelatedImage);
+    $imagePathParam = mb_substr($imageUrl, mb_strpos($imageUrl, 'path=') + mb_strlen('path='));
+
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'No images here.',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+
+    $this->get(route('share.files', ['share' => $share->token]) . '?path=' . $imagePathParam)
+        ->assertStatus(404);
+});
+
+it('never serves a markdown file through the share files endpoint', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $otherNote = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => 'secret',
+        'extension' => 'md',
+        'content' => 'Top secret content',
+    ]);
+
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => '![alt](/secret.md)',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+
+    $this->get(route('share.files', ['share' => $share->token]) . '?path=/secret.md')
+        ->assertStatus(404);
+});

--- a/tests/Feature/Web/Share/ShowShareTest.php
+++ b/tests/Feature/Web/Share/ShowShareTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateVault;
+use App\Actions\CreateVaultNode;
+use App\Actions\CreateVaultNodeShare;
+use App\Actions\UpdateVaultNode;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('renders a shared note to an unauthenticated visitor', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => 'My note',
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+
+    $this->get(route('share.show', ['share' => $share->token]))
+        ->assertStatus(200)
+        ->assertInertia(
+            fn(Assert $page): Assert => $page
+                ->where('share.token', $share->token)
+                ->where('share.name', 'My note')
+                ->where('share.content', 'Hello world')
+        );
+});
+
+it('reflects the current note content, not a snapshot', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Original content',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+
+    new UpdateVaultNode()->handle($note, ['content' => 'Updated content']);
+
+    $this->get(route('share.show', ['share' => $share->token]))
+        ->assertInertia(
+            fn(Assert $page): Assert => $page->where('share.content', 'Updated content')
+        );
+});
+
+it('returns a 404 error for an unknown token', function (): void {
+    $this->get(route('share.show', ['share' => 'unknown-token']))
+        ->assertStatus(404);
+});
+
+it('returns a 404 error after a share link is revoked', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+    $token = $share->token;
+
+    $share->delete();
+
+    $this->get(route('share.show', ['share' => $token]))
+        ->assertStatus(404);
+});
+
+it('returns a 404 error after the shared note is deleted', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+    $token = $share->token;
+
+    $note->delete();
+
+    $this->get(route('share.show', ['share' => $token]))
+        ->assertStatus(404);
+});

--- a/tests/Feature/Web/Vaults/CreateVaultNodeShareTest.php
+++ b/tests/Feature/Web/Vaults/CreateVaultNodeShareTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateVault;
+use App\Actions\CreateVaultNode;
+use App\Models\User;
+
+it('creates a share link for a note', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+
+    $this->actingAs($user);
+
+    $response = $this->post(
+        route('vaults.nodes.share.store', ['vault' => $vault->id, 'node' => $note->id]),
+    );
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure(['data' => ['token', 'url']]);
+    expect($note->fresh()->share)->not->toBeNull();
+});
+
+it('returns the same token when a note is already shared', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+
+    $this->actingAs($user);
+
+    $firstResponse = $this->post(
+        route('vaults.nodes.share.store', ['vault' => $vault->id, 'node' => $note->id]),
+    );
+    $secondResponse = $this->post(
+        route('vaults.nodes.share.store', ['vault' => $vault->id, 'node' => $note->id]),
+    );
+
+    expect($firstResponse->json('data.token'))->toBe($secondResponse->json('data.token'));
+});
+
+it('does not allow a collaborator without access to share a note', function (): void {
+    [$user1, $user2] = User::factory(2)->create();
+    $vault = new CreateVault()->handle($user1, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+
+    $this->actingAs($user2);
+
+    $response = $this->post(
+        route('vaults.nodes.share.store', ['vault' => $vault->id, 'node' => $note->id]),
+    );
+
+    $response->assertStatus(403);
+    expect($note->fresh()->share)->toBeNull();
+});
+
+it('does not allow sharing a folder', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $folder = new CreateVaultNode()->handle($vault, [
+        'is_file' => false,
+        'name' => fake()->words(3, true),
+    ]);
+
+    $this->actingAs($user);
+
+    $response = $this->post(
+        route('vaults.nodes.share.store', ['vault' => $vault->id, 'node' => $folder->id]),
+    );
+
+    $response->assertStatus(422);
+});

--- a/tests/Feature/Web/Vaults/DeleteVaultNodeShareTest.php
+++ b/tests/Feature/Web/Vaults/DeleteVaultNodeShareTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateVault;
+use App\Actions\CreateVaultNode;
+use App\Actions\CreateVaultNodeShare;
+use App\Models\User;
+
+it('revokes a share link', function (): void {
+    $user = User::factory()->create();
+    $vault = new CreateVault()->handle($user, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+    $share = new CreateVaultNodeShare()->handle($note);
+
+    $this->actingAs($user);
+
+    $response = $this->delete(
+        route('vaults.nodes.share.destroy', ['vault' => $vault->id, 'node' => $note->id]),
+    );
+
+    $response->assertStatus(200);
+    expect($note->fresh()->share)->toBeNull();
+
+    $this->get(route('share.show', ['share' => $share->token]))->assertStatus(404);
+});
+
+it('does not allow a user without access to revoke a share link', function (): void {
+    [$user1, $user2] = User::factory(2)->create();
+    $vault = new CreateVault()->handle($user1, [
+        'name' => fake()->words(3, true),
+    ]);
+    $note = new CreateVaultNode()->handle($vault, [
+        'is_file' => true,
+        'name' => fake()->words(3, true),
+        'extension' => 'md',
+        'content' => 'Hello world',
+    ]);
+    new CreateVaultNodeShare()->handle($note);
+
+    $this->actingAs($user2);
+
+    $response = $this->delete(
+        route('vaults.nodes.share.destroy', ['vault' => $vault->id, 'node' => $note->id]),
+    );
+
+    $response->assertStatus(403);
+    expect($note->fresh()->share)->not->toBeNull();
+});


### PR DESCRIPTION
Hello!

First of all big fan of the app, been really enjoying it.

I was looking through the following issues/discussions for adding read-only note publishing:
https://github.com/brufdev/many-notes/issues/46
https://github.com/brufdev/many-notes/discussions/47

I built this feature for myself anyway but I was wondering if it would be feasible to get it review and pushed upstream. If you have the bandwidth please take a look and lmk. Happy to iterate on this as well for it to align with the overall app design if any current behavior/patterns are not desired.

---

The change is architectured as follows:

### Database

One new table: **`vault_node_shares`**
- `id`
- `vault_node_id` - FK to `vault_nodes`, unique (so a note can have at most one active share), `cascadeOnDelete()` (deleting the note automatically revokes its share)
- `token` - random 48-char string, unguessable, used as the public URL identifier instead of the numeric ID
- timestamps

### Relationships

- `VaultNode::share()` → `hasOne(VaultNodeShare)`
- `VaultNodeShare::node()` → `belongsTo(VaultNode)`

### Authorization

`VaultNodePolicy::share()` -  same rule as the existing `delete()` ability: the vault owner or an accepted collaborator. Nothing else can create or revoke a link.

### Routes

**Authenticated** - (inside the existing `auth` middleware group, under `vaults/{vault}/nodes/{node}`):
- `POST .../share` - create (or return existing) link
- `DELETE .../share` - revoke

**Public** - a new route group that sits outside both `auth` and `guest` middleware (works whether you're logged in or not), keyed by the token via Laravel's `{share:token}` route-model binding:
- `GET /share/{token}` - renders the read-only note page
- `GET /share/{token}/files?path=...` - serves images embedded in that note
   - The app already has `/files/{vault}?path=...` for serving attachments, but that endpoint checks "can this user view the whole vault
   - `/share/{token}/files` instead re-parses the note's current markdown content on every request, extracts just the image paths actually referenced in it, and only serves those  (unsure if this is preferred from a design perspective but lmk thoughts)

---

<img width="853" height="345" alt="Screenshot 2026-08-05 at 1 55 36 PM" src="https://github.com/user-attachments/assets/3c3be4ca-d783-43e5-a634-936b93e66d32" />
<img width="924" height="408" alt="Screenshot 2026-08-05 at 1 55 45 PM" src="https://github.com/user-attachments/assets/e1c57610-bb1f-43da-b21c-693e3144f381" />
<img width="783" height="275" alt="Screenshot 2026-08-05 at 1 56 04 PM" src="https://github.com/user-attachments/assets/3c4c2195-b8cf-4958-9f43-19beee49470c" />
<img width="806" height="359" alt="Screenshot 2026-08-05 at 1 56 47 PM" src="https://github.com/user-attachments/assets/b91c830b-0966-4994-aea9-600f1db6a627" />
<img width="786" height="362" alt="Screenshot 2026-08-05 at 1 56 51 PM" src="https://github.com/user-attachments/assets/9c22b58b-7fa4-4665-85e7-6426cd1885c2" />
<img width="734" height="261" alt="Screenshot 2026-08-05 at 1 57 32 PM" src="https://github.com/user-attachments/assets/42af899a-a653-4155-8912-616c3b2add50" />
<img width="822" height="705" alt="Screenshot 2026-08-05 at 1 59 59 PM" src="https://github.com/user-attachments/assets/09e118d6-8a4f-498a-bd64-650121a9ea23" />
<img width="1728" height="1117" alt="Screenshot 2026-08-05 at 2 32 43 PM" src="https://github.com/user-attachments/assets/71000942-76d7-4dba-b66e-a30e6336e03c" />

What the button looks like after hitting copy to clipboard (goes away after 1 second):
<img width="113" height="47" alt="Screenshot 2026-08-05 at 2 33 06 PM" src="https://github.com/user-attachments/assets/7c621bfc-f69f-434a-b4f7-f0e2f6c61c76" />


Also here is what the settings button shows, I didn't use the entire header for the read-only mode because it seemed cleaner to not have it when it would contain very limited controls. Also I didn't use the person icon and instead used the gear since technically in read only mode the user is a guest. Let me know any thoughts around this happy to change it:
<img width="233" height="185" alt="image" src="https://github.com/user-attachments/assets/82202f34-1f26-4938-a133-5a5c4af59926" />



